### PR TITLE
Fix module_name

### DIFF
--- a/etc/modules/vmware-autolinking.cfg
+++ b/etc/modules/vmware-autolinking.cfg
@@ -5,7 +5,7 @@
 # connect to vcenter from time to time and update dependencies.
 # Arbiter restart required to apply updated configurations.
 define module {
-    module_name         vmware-auto-linking
+    module_name         VMWare_auto_linking
     module_type         hot_dependencies
     mapping_file        /tmp/vmware_mapping_file.json
     mapping_command     /var/lib/shinken/libexec/link_vmware_host_vm.py -x '/var/lib/shinken/libexec/check_esx3.pl' -V 'vcenter.mydomain.com' -u 'admin' -p 'secret' -r 'lower|nofqdn' -o /tmp/vmware_mapping_file.json


### PR DESCRIPTION
This is "module_name" used in the doc and "/etc/shinken/arbiters/arbiter-master.cfg".
